### PR TITLE
헤더 고정 + 스크롤 / 바텀시트 구현

### DIFF
--- a/bigone/src/pages/BottomSheet.jsx
+++ b/bigone/src/pages/BottomSheet.jsx
@@ -1,0 +1,14 @@
+import React, { use, useRef, useState } from "react";
+import * as B from "../styles/StyledBottom";
+
+const BottomSheet = ({ isOpen, onClose, children }) => {
+  return (
+    <B.Overlay isOpen={isOpen} onClick={onClose}>
+      <B.BottomSheet isOpen={isOpen} onClick={(e) => e.stopPropagation()}>
+        {children}
+      </B.BottomSheet>
+    </B.Overlay>
+  );
+};
+
+export default BottomSheet;

--- a/bigone/src/pages/PurDetail.jsx
+++ b/bigone/src/pages/PurDetail.jsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as P from "../styles/StyledPurD";
+import BottomSheet from "./BottomSheet";
 
 const P_Detail = () => {
   const navigate = useNavigate();
   const goPur = () => {
     navigate(`/purchase`);
   };
+
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <P.Container>
@@ -53,11 +56,12 @@ const P_Detail = () => {
           <p>공동구매 링크</p>
           <a href="https://open.kakao.com/o/szqBpBlh">https://open.kakao.com/o/szqBpBlh</a>
         </P.PostURL>
-        <P.Comment>
+        <P.Comment onClick={() => setIsOpen(true)}>
           <img id="comment" src={`${process.env.PUBLIC_URL}/images/comment_w.svg`} alt="comment" />
           <div id="comment_cnt">21</div>
         </P.Comment>
       </P.Content>
+      <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}></BottomSheet>
     </P.Container>
   );
 };

--- a/bigone/src/styles/StyledBottom.jsx
+++ b/bigone/src/styles/StyledBottom.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "styled-components";
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? "auto" : "none")};
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+`;
+
+export const BottomSheet = styled.div`
+  position: fixed;
+  bottom: 0;
+  background-color: #fff;
+  border-top-left-radius: 30px;
+  border-top-right-radius: 30px;
+  transform: ${({ isOpen }) => (isOpen ? "translateY(0)" : "translateY(100%)")};
+  transition: transform 0.3s ease;
+  overflow-y: auto;
+  height: 90vh;
+  width: 393px;
+
+  -ms-overflow-style: none; /* IE & Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari */
+  }
+`;

--- a/bigone/src/styles/StyledPur.jsx
+++ b/bigone/src/styles/StyledPur.jsx
@@ -16,8 +16,14 @@ export const Container = styled.div`
 `;
 
 export const Header = styled.div`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+
   height: 80px;
-  width: 100%;
+  width: 393px;
   display: flex;
   flex-direction: row;
   padding: 20px;

--- a/bigone/src/styles/StyledPurD.jsx
+++ b/bigone/src/styles/StyledPurD.jsx
@@ -16,8 +16,15 @@ export const Container = styled.div`
 `;
 
 export const Header = styled.div`
+  /* 스크롤 만들기 위해 추가 */
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+
   height: 80px;
-  width: 100%;
+  width: 393px;
   display: flex;
   flex-direction: row;
   padding: 20px;
@@ -54,11 +61,13 @@ export const Icons = styled.div`
 `;
 
 export const Content = styled.div`
+  margin-top: 60px;
   padding: 20px;
 
   overflow-y: auto;
   &::-webkit-scrollbar {
     display: none;
+  }
 `;
 
 export const Pic = styled.div`

--- a/bigone/src/styles/StyledPurW.jsx
+++ b/bigone/src/styles/StyledPurW.jsx
@@ -16,8 +16,15 @@ export const Container = styled.div`
 `;
 
 export const Header = styled.div`
+  /* 스크롤 만들기 위해 추가 */
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+
   height: 80px;
-  width: 100%;
+  width: 393px;
   display: flex;
   flex-direction: row;
   padding: 17px; /* 아이콘 여백 조절으로 인해 변경 */
@@ -42,7 +49,14 @@ export const Icons = styled.div`
 `;
 
 export const Content = styled.div`
+  margin-top: 60px;
   padding: 20px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 export const InputWrapper = styled.div`


### PR DESCRIPTION
- 페이지 추가 없음
바텀 시트가 피그마에서는 2단으로 나눠서 올라오게 되어야하는데.. 역량 부족으로 처음부터 크게 올라오게 구현해놓음 (기디랑 상의했어요...ㅎ)
헤더 고정하느라 css 조금 변동있는데, 주석으로 표시해뒀습니다!!